### PR TITLE
Make the notification channel optional

### DIFF
--- a/examples/one_gb_cache.rs
+++ b/examples/one_gb_cache.rs
@@ -24,7 +24,7 @@ fn main() {
                 size_range: (MB, 10 * MB),   // 1MB-10MB
             },
         ],
-        update_channel_size: 1024,
+        update_channel_size: None,
     };
 
     let cache = AutoCache::<Vec<u8>, Vec<u8>>::new(config);

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ pub struct CacheConfig {
     /// Vector of tier configurations, ordered from smallest to largest size
     pub tiers: Vec<TierConfig>,
     /// Size of the channel used for cache update notifications
-    pub update_channel_size: usize,
+    pub update_channel_size: Option<usize>,
 }
 
 /// Configuration for a single cache tier

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ where
     tiers: TierVec<K, V>,
     key_to_tier: Arc<DashMap<K, usize>>,
     config: Arc<CacheConfig>,
-    update_tx: broadcast::Sender<K>,
+    update_tx: Option<broadcast::Sender<K>>,
 }
 
 impl<K, V> AutoCache<K, V>
@@ -61,7 +61,9 @@ where
             .map(|t| t.total_capacity)
             .sum();
 
-        let (tx, _) = broadcast::channel(config.update_channel_size);
+        let tx = config
+            .update_channel_size
+            .map(|size| broadcast::channel(size).0);
 
         Self {
             tiers,
@@ -130,13 +132,13 @@ where
 
     /// Subscribes to cache updates
     #[inline]
-    pub fn subscribe_updates(&self) -> broadcast::Receiver<K> {
-        self.update_tx.subscribe()
+    pub fn subscribe_updates(&self) -> Option<broadcast::Receiver<K>> {
+        self.update_tx.as_ref().map(|tx| tx.subscribe())
     }
 
     #[inline]
     fn notify_update(&self, key: K) {
-        let _ = self.update_tx.send(key);
+        self.update_tx.as_ref().map(|tx| tx.send(key));
     }
 
     #[inline]


### PR DESCRIPTION
My application doesn't need it, and probably a bunch more as well, so this changes the interface so that you can just pass None as the size, and the channel is never created or used.

This could probably be a bit better -- you could have a type that supports notifications and a type that doesn't, avoiding the error of asking to subscribe when there is no channel.