### PR TITLE
Rkuris/fix move case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,11 +256,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown",
  "lock_api",
  "once_cell",
@@ -442,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "lock_api"
@@ -808,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ categories = ["caching", "data-structures"]
 [dependencies]
 lru-mem = "0.3"
 parking_lot = "0.12"
-dashmap = "5.5"
-tokio = { version = "1.0", features = ["sync", "time", "rt-multi-thread"] }
+dashmap = "6.1.0"
+tokio = { version = "1.41.1", features = ["sync", "time", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }
 futures = "0.3"
 smallvec = "1.11"

--- a/examples/one_gb_cache.rs
+++ b/examples/one_gb_cache.rs
@@ -1,8 +1,6 @@
-use std::time::Duration;
 use tiered_cache::{AutoCache, CacheConfig, TierConfig};
 
 const MB: usize = 1024 * 1024; // 1 megabyte
-const GB: usize = 1024 * MB;   // 1 gigabyte
 
 fn main() {
     // Configure a 1GB cache with three tiers:
@@ -13,7 +11,7 @@ fn main() {
         tiers: vec![
             TierConfig {
                 total_capacity: 200 * MB,
-                size_range: (0, 64 * 1024),  // 0-64KB
+                size_range: (0, 64 * 1024), // 0-64KB
             },
             TierConfig {
                 total_capacity: 300 * MB,
@@ -21,7 +19,7 @@ fn main() {
             },
             TierConfig {
                 total_capacity: 500 * MB,
-                size_range: (MB, 10 * MB),   // 1MB-10MB
+                size_range: (MB, 10 * MB), // 1MB-10MB
             },
         ],
         update_channel_size: 1024,
@@ -32,9 +30,9 @@ fn main() {
     // Example usage
     let key = b"example".to_vec();
     let value = vec![0u8; 500 * 1024]; // 500KB value
-    
+
     cache.put(key.clone(), value);
-    
+
     if let Some(retrieved) = cache.get(&key) {
         println!("Retrieved value of size: {} bytes", retrieved.len());
     }
@@ -44,7 +42,7 @@ fn main() {
     println!("Cache statistics:");
     println!("Total items: {}", stats.total_items);
     println!("Total size: {} MB", stats.total_size / MB);
-    
+
     for (i, tier) in stats.tier_stats.iter().enumerate() {
         println!("\nTier {}:", i);
         println!("  Items: {}", tier.items);

--- a/examples/one_gb_cache.rs
+++ b/examples/one_gb_cache.rs
@@ -1,4 +1,4 @@
-use tiered_cache::{AutoCache, CacheConfig, TierConfig};
+use tiered_cache::{CacheConfig, TierConfig, TieredCache};
 
 const MB: usize = 1024 * 1024; // 1 megabyte
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,6 @@ pub struct CacheConfig {
 pub struct TierConfig {
     /// Maximum total capacity of the tier in bytes
     pub total_capacity: usize,
-    /// Valid size range for entries in this tier as (min_size, max_size) in bytes
+    /// Valid size range for entries in this tier as (`min_size`, `max_size`) in bytes
     pub size_range: (usize, usize),
 }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
 use lru_mem::HeapSize;
+use std::sync::Arc;
 
-#[allow(dead_code)]
+#[derive(Debug)]
 pub(crate) struct CacheEntry<V> {
     pub value: Arc<V>,
-    pub size: usize,
+    pub _size: usize,
 }
 
 impl<V: HeapSize> HeapSize for CacheEntry<V> {
@@ -17,7 +17,7 @@ impl<V> CacheEntry<V> {
     pub fn new(value: V, size: usize) -> Self {
         Self {
             value: Arc::new(value),
-            size,
+            _size: size,
         }
     }
 }

--- a/src/tier.rs
+++ b/src/tier.rs
@@ -1,10 +1,10 @@
+use super::{Arc, CacheEntry, Hash, RwLock, TierConfig, TierStats};
 use lru_mem::HeapSize;
-use super::{RwLock, CacheEntry, Hash, Arc, TierConfig, TierStats};
 
 #[derive(Debug)]
 pub(crate) struct Tier<K, V> {
     cache: RwLock<lru_mem::LruCache<K, CacheEntry<V>>>,
-    _size_range: (usize, usize),
+    pub size_range: (usize, usize),
 }
 
 impl<K, V> Tier<K, V>
@@ -15,7 +15,7 @@ where
     pub fn new(capacity: usize, size_range: (usize, usize)) -> Self {
         Self {
             cache: RwLock::new(lru_mem::LruCache::new(capacity)),
-            _size_range: size_range,
+            size_range,
         }
     }
 


### PR DESCRIPTION
Fix case where item changes tier
    
Also optimized the find tier case. There are never enough tiers to warrant using a binary search for them; just find the first one that can hold the value.
    
Note that currently the low value isn't even used, and probably could be removed from the interface. Additionally, passing a list that isn't ordered can cause problems, as the higher tiers will never get used.